### PR TITLE
fix: use crossplane instead of kubectl-crossplane, added backward com…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: asdf_plugin_test
-      uses: asdf-vm/actions/plugin-test@v1
+      uses: asdf-vm/actions/plugin-test@v4
       with:
-        command: kubectl-crossplane --help
+        command: crossplane --help

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,23 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v6.0.0
   hooks:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/syntaqx/git-hooks
-  rev: v0.0.17
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.9.0.6
   hooks:
   - id: shellcheck
-  - id: shfmt
-- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.7.0
+    args: [-x, --source-path=SCRIPTDIR]
+- repo: https://github.com/scop/pre-commit-shfmt
+  rev: v3.7.0-1
   hooks:
-  - id: pretty-format-yaml
-    args:
-    - --autofix
-    - --indent
-    - '2'
+  - id: shfmt
+    args: [-i, '2', -bn, -ci, -sr]
+- repo: https://github.com/adrienverge/yamllint
+  rev: v1.35.1
+  hooks:
+  - id: yamllint
+    args: [--strict]

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,23 @@
+---
+extends: default
+
+rules:
+  # Allow 2-space indentation which is the project standard
+  # indent-sequences: whatever allows lists at same level as parent key
+  indentation:
+    spaces: 2
+    indent-sequences: whatever
+    check-multi-line-strings: false
+  
+  # Document start is optional
+  document-start: disable
+  
+  # Allow "on" as a truthy value (common in GitHub Actions)
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off']
+  
+  # Line length can be longer
+  line-length:
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true

--- a/.yamllint
+++ b/.yamllint
@@ -8,14 +8,14 @@ rules:
     spaces: 2
     indent-sequences: whatever
     check-multi-line-strings: false
-  
+
   # Document start is optional
   document-start: disable
-  
+
   # Allow "on" as a truthy value (common in GitHub Actions)
   truthy:
     allowed-values: ['true', 'false', 'on', 'off']
-  
+
   # Line length can be longer
   line-length:
     max: 120

--- a/README.adoc
+++ b/README.adoc
@@ -7,3 +7,23 @@ https://github.com/crossplane/crossplane-cli[crossplane-cli] plugin for https://
 ```
 asdf plugin-add crossplane-cli https://github.com/joke/asdf-crossplance-cli.git
 ```
+
+== Configuration
+
+=== Customizing the Executable Name
+
+By default, the plugin installs the Crossplane CLI as `crossplane`. You can customize the executable name by setting the `ASDF_CROSSPLANE_EXECUTABLE_NAME` environment variable:
+
+```bash
+# Install as 'crossplane' (default)
+asdf install crossplane-cli latest
+
+# Install as 'kubectl-crossplane' for backward compatibility
+export ASDF_CROSSPLANE_EXECUTABLE_NAME=kubectl-crossplane
+asdf install crossplane-cli latest
+
+# Or set it inline
+ASDF_CROSSPLANE_EXECUTABLE_NAME=kubectl-crossplane asdf install crossplane-cli latest
+```
+
+This is useful for backward compatibility if you have scripts or tools that expect a different executable name.

--- a/bin/download
+++ b/bin/download
@@ -11,7 +11,11 @@ source "${plugin_dir}/lib/utils.bash"
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
 platform="$(detect_system)_$(detect_architecture)"
-release_file="$ASDF_DOWNLOAD_PATH/$EXECUTABLE_NAME"
+# Download the binary as 'crank' (the name used in Crossplane releases)
+crank_file="$ASDF_DOWNLOAD_PATH/crank"
 
 # Download file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$platform" "$release_file"
+download_release "$ASDF_INSTALL_VERSION" "$platform" "$crank_file"
+
+# Rename crank to the configured executable name
+mv "$crank_file" "$ASDF_DOWNLOAD_PATH/$EXECUTABLE_NAME"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -4,7 +4,9 @@ set -euo pipefail
 
 RELEASES="https://releases.crossplane.io"
 TOOL_NAME="crossplane-cli"
-EXECUTABLE_NAME="kubectl-crossplane"
+# Allow users to override the executable name via environment variable
+# Default is 'crossplane', but can be customized for backward compatibility
+EXECUTABLE_NAME="${ASDF_CROSSPLANE_EXECUTABLE_NAME:-crossplane}"
 
 fail() {
   echo -e "asdf-$TOOL_NAME: $*"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -16,14 +16,14 @@ fail() {
 curl_opts=(-fsSL)
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' \
+    | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
 list_all_versions() {
-  curl "${curl_opts[@]}" 'https://s3-us-west-2.amazonaws.com/crossplane.releases?delimiter=/&prefix=stable/' |
-    grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' |
-    sed 's/v//g'
+  curl "${curl_opts[@]}" 'https://s3-us-west-2.amazonaws.com/crossplane.releases?delimiter=/&prefix=stable/' \
+    | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' \
+    | sed 's/v//g'
 }
 
 detect_system() {


### PR DESCRIPTION
The problem: 
The cli is installed gets installed as `kubectl-crossplane` instead of only `crossplane` creating an optional dependency and confusion on the kubectl cli.

Official crossplane [installation script](https://raw.githubusercontent.com/crossplane/crossplane/main/install.sh) install the crossplane cli as `crossplane`

Arguably, crossplane can be used without kubernetes in some development scenario e.g. `crossplane render ...`

This PR change the default behavior to install crossplane as crossplane and add support for override using env variable for backward compatibility.